### PR TITLE
Prevent exception deep in PySimpleGUI if data is empty

### DIFF
--- a/company.py
+++ b/company.py
@@ -99,18 +99,22 @@ class Company:
     def open_bank_transactions(self):
         bts = gui_api_wrapper(Api.api.get_list,'Bank Transaction',
                                                 filters={'company':self.name,
-                                                         'status':'Pending'})
+                                                         'status':'Pending'},
+                                                limit_page_length=LIMIT)
         return list(filter(lambda bt: \
                         (not 'payment_entries' in bt) or (not bt['payment_entries']),bts))
     def open_journal_entries(self):
         return gui_api_wrapper(Api.api.get_list,'Journal Entry',
                                                 filters={'company':self.name,
-                                                         'docstatus':0})
+                                                         'docstatus':0},
+                                                limit_page_length=LIMIT)
     def open_payment_entries(self):
         return gui_api_wrapper(Api.api.get_list,'Payment Entry',
                                                 filters={'company':self.name,
-                                                         'docstatus':0})
+                                                         'docstatus':0},
+                                                limit_page_length=LIMIT)
     def open_purchase_invoices(self):
         return gui_api_wrapper(Api.api.get_list,'Purchase Invoice',
                                                 filters={'company':self.name,
-                                                         'docstatus':0})
+                                                         'docstatus':0},
+                                                limit_page_length=LIMIT)

--- a/menu.py
+++ b/menu.py
@@ -87,7 +87,7 @@ def show_table(entries,keys,headings,title,enable_events=False,max_col_width=60)
     layout = [[sg.SaveAs(button_text = 'CSV-Export',
                          default_extension = 'csv',enable_events=True)],
               [sg.Table(values=data, headings=headings, max_col_width=max_col_width,
-               auto_size_columns=True,
+               auto_size_columns=len(data) > 0,
                display_row_numbers=True,
                justification='left',
                num_rows=30,


### PR DESCRIPTION
Anzeigen->Buchungssätze (and the other options) fails with an exception deep in PySimpleGUI in line
```
window1 = sg.Window(title, layout, finalize=True)
```

Apparently, the automatic calculation of the column sizes causes this exception for an empty table. This patch adds a workaround for this bug in PySimpleGUI by disabling `auto_size_columns` if `data` is empty.